### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ COPY website/ ./
 RUN npm run build
 
 # Stage 2: Production runtime
-FROM mcr.microsoft.com/playwright:v1.40.0-focal
+FROM mcr.microsoft.com/playwright:v1.55.0-noble
 
 # Install additional system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Hello! This PR fixes a critical runtime error that occurs when making API calls to endpoints that launch a browser.

### The Problem

When the Docker image is built, `npm install` fetches a recent version of the `playwright` library (e.g., v1.55.0). However, the `Dockerfile` was previously pinned to an older base image (`mcr.microsoft.com/playwright:v1.40.0-focal`).

This creates a version mismatch between the Playwright library and the browser executables provided within the Docker image. The new library looks for the browser in a path that doesn't exist in the old image, leading to this specific runtime error:

```Error: Browser launch failed: browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell```

### The Solution

This change updates the Playwright base image in the `Dockerfile` to a more recent version that is compatible with the latest libraries.

**Changed from:**
`FROM mcr.microsoft.com/playwright:v1.40.0-focal`

**Changed to:**
`FROM mcr.microsoft.com/playwright:v1.55.0-noble`

This ensures that the browser executables are in the location expected by the Node.js library, allowing the application to function correctly. This is a minimal but essential change to fix the project's current runtime state.