### PR TITLE
Use configurable dashboard API key for UI requests

### DIFF
--- a/backend/src/middleware/ApiKeyGuard.ts
+++ b/backend/src/middleware/ApiKeyGuard.ts
@@ -15,6 +15,7 @@ export const ApiKeyGuard = async (req: Request, res: Response, next: NextFunctio
     try {
         const apiKey = req.headers['x-api-key'] as string;
         const clientIp = req.ip || req.socket.remoteAddress;
+        const dashboardApiKey = process.env.DASHBOARD_INTERNAL_API_KEY || 'dashboard-internal';
 
         // 1. Internal / Localhost Trust
         // If request is from localhost, allow it (Dashboard usage)
@@ -24,7 +25,7 @@ export const ApiKeyGuard = async (req: Request, res: Response, next: NextFunctio
         }
 
         // 2. Dashboard internal key (for frontend-backend communication)
-        if (apiKey === 'dashboard-internal' || apiKey === 'test-key-dashboard') {
+        if (apiKey === dashboardApiKey) {
             req.isInternal = true;
             return next();
         }

--- a/frontend/src/app/api-keys/page.tsx
+++ b/frontend/src/app/api-keys/page.tsx
@@ -10,26 +10,36 @@ import { ApiKeysList, ApiKey } from "@/components/api-keys/ApiKeysList";
 import { CreateKeyDialog } from "@/components/api-keys/CreateKeyDialog";
 import { DeleteKeyDialog } from "@/components/api-keys/DeleteKeyDialog";
 
+const DASHBOARD_API_KEY = process.env.NEXT_PUBLIC_DASHBOARD_API_KEY || 'dashboard-internal';
+
 const fetchKeys = async () => {
-    const res = await fetch('/api/keys');
+    const res = await fetch('/api/keys', {
+        headers: { 'x-api-key': DASHBOARD_API_KEY }
+    });
     return res.json();
 };
 
 const createKey = async (name: string) => {
     const res = await fetch('/api/keys', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'x-api-key': DASHBOARD_API_KEY },
         body: JSON.stringify({ name })
     });
     return res.json();
 };
 
 const revokeKey = async (id: string) => {
-    await fetch(`/api/keys/${id}/revoke`, { method: 'PATCH' });
+    await fetch(`/api/keys/${id}/revoke`, {
+        method: 'PATCH',
+        headers: { 'x-api-key': DASHBOARD_API_KEY }
+    });
 };
 
 const deleteKey = async (id: string) => {
-    await fetch(`/api/keys/${id}`, { method: 'DELETE' });
+    await fetch(`/api/keys/${id}`, {
+        method: 'DELETE',
+        headers: { 'x-api-key': DASHBOARD_API_KEY }
+    });
 };
 
 export default function ApiKeysPage() {

--- a/frontend/src/app/playground/google-serp/page.tsx
+++ b/frontend/src/app/playground/google-serp/page.tsx
@@ -8,9 +8,9 @@ import { ConfigurationPanel } from '@/components/playground/google-serp/Configur
 import { ResultsPanel } from '@/components/playground/google-serp/ResultsPanel';
 import { SearchResponse, Profile, ProgressStep } from '@/components/playground/google-serp/types';
 
+const DASHBOARD_API_KEY = process.env.NEXT_PUBLIC_DASHBOARD_API_KEY || 'dashboard-internal';
+
 const fetchProfiles = async () => {
-    // Dashboard API key from environment or fallback
-    const DASHBOARD_API_KEY = process.env.NEXT_PUBLIC_DASHBOARD_API_KEY || 'dashboard-internal';
     const res = await fetch('/api/profiles', {
         headers: { 'x-api-key': DASHBOARD_API_KEY }
     });
@@ -87,7 +87,7 @@ export default function GoogleSerpPage() {
                 method: 'GET',
                 headers: {
                     'Accept': 'text/event-stream',
-                    'x-api-key': 'test-key-dashboard', // Dashboard API key
+                    'x-api-key': DASHBOARD_API_KEY
                 },
             });
 

--- a/frontend/src/app/playground/website/page.old.tsx
+++ b/frontend/src/app/playground/website/page.old.tsx
@@ -179,6 +179,8 @@ const OUTPUT_TYPES: { id: OutputType; label: string; icon: LucideIcon }[] = [
     { id: 'pdf', label: 'PDF', icon: FileDown },
 ];
 
+const DASHBOARD_API_KEY = process.env.NEXT_PUBLIC_DASHBOARD_API_KEY || 'dashboard-internal';
+
 // Profile type
 interface Profile {
     id: string;
@@ -192,7 +194,7 @@ interface Profile {
 // Fetch profiles
 const fetchProfiles = async () => {
     const res = await fetch('/api/profiles', {
-        headers: { 'x-api-key': 'dashboard-internal' }
+        headers: { 'x-api-key': DASHBOARD_API_KEY }
     });
     return res.json();
 };
@@ -492,7 +494,7 @@ export default function WebsiteScraperPage() {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'x-api-key': 'test-key-dashboard'
+                    'x-api-key': DASHBOARD_API_KEY
                 },
                 body: JSON.stringify({
                     url,

--- a/frontend/src/app/playground/website/page.tsx
+++ b/frontend/src/app/playground/website/page.tsx
@@ -9,10 +9,12 @@ import { ScraperHeader } from '@/components/playground/website/ScraperHeader';
 import { ConfigurationPanel } from '@/components/playground/website/ConfigurationPanel';
 import { ResultsPanel } from '@/components/playground/website/ResultsPanel';
 
+const DASHBOARD_API_KEY = process.env.NEXT_PUBLIC_DASHBOARD_API_KEY || 'dashboard-internal';
+
 // Fetch profiles
 const fetchProfiles = async () => {
     const res = await fetch('/api/profiles', {
-        headers: { 'x-api-key': process.env.NEXT_PUBLIC_DASHBOARD_API_KEY || 'dashboard-internal' }
+        headers: { 'x-api-key': DASHBOARD_API_KEY }
     });
     // Handle potential API transform if needed, or assume consistent response
     return res.json();
@@ -98,7 +100,7 @@ function WebsiteScraperContent() {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'x-api-key': 'test-key-dashboard' // Should use env var in prod
+                    'x-api-key': DASHBOARD_API_KEY
                 },
                 body: JSON.stringify({
                     url,

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -22,16 +22,18 @@ import { cn } from "@/lib/utils";
 import { PageHeader } from "@/components/ui/PageHeader";
 import ProxiesTab from "@/components/dashboard/ProxiesTab";
 
+const DASHBOARD_API_KEY = process.env.NEXT_PUBLIC_DASHBOARD_API_KEY || 'dashboard-internal';
+
 // --- API Functions ---
 const fetchConfig = async () => {
-    const res = await fetch('/api/config', { headers: { 'x-api-key': 'dashboard-internal' } });
+    const res = await fetch('/api/config', { headers: { 'x-api-key': DASHBOARD_API_KEY } });
     return res.json();
 };
 
 const updateConfig = async (data: any) => {
     const res = await fetch('/api/config', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', 'x-api-key': 'dashboard-internal' },
+        headers: { 'Content-Type': 'application/json', 'x-api-key': DASHBOARD_API_KEY },
         body: JSON.stringify(data),
     });
     const json = await res.json();


### PR DESCRIPTION
### Motivation
- The dashboard UI was using hardcoded keys (`test-key-dashboard`/`dashboard-internal`) which caused 401/403 when creating API keys and left the panel insecure.
- Requests originating from the frontend need to send a dashboard/internal API key so the backend can authenticate dashboard operations.
- The internal dashboard key should be configurable via environment variables instead of relying on multiple hardcoded values.

### Description
- Backend: read `process.env.DASHBOARD_INTERNAL_API_KEY || 'dashboard-internal'` in `ApiKeyGuard` and treat that value as the internal dashboard key validated on requests (file: `backend/src/middleware/ApiKeyGuard.ts`).
- Frontend: standardize dashboard key usage by introducing `DASHBOARD_API_KEY = process.env.NEXT_PUBLIC_DASHBOARD_API_KEY || 'dashboard-internal'` and include `x-api-key` headers on dashboard API calls (files: `frontend/src/app/api-keys/page.tsx`, `frontend/src/app/settings/page.tsx`, `frontend/src/app/playground/website/page.tsx`, `frontend/src/app/playground/google-serp/page.tsx`, and `frontend/src/app/playground/website/page.old.tsx`).
- Replace occurrences of the hardcoded `test-key-dashboard` and direct `'dashboard-internal'` string usage with the centralized `DASHBOARD_API_KEY` to ensure consistent behavior and allow configuration in production.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989c0fac97083259bc857b1a58cdd3d)